### PR TITLE
Img_to_base64を実装

### DIFF
--- a/hot-finder/src/img_util.rs
+++ b/hot-finder/src/img_util.rs
@@ -5,8 +5,7 @@ use base64::{Engine as _, alphabet, engine::{self, general_purpose}};
 #[wasm_bindgen]
 pub fn img_to_base64(img: Vec<u8>, put_html_data_header: bool) -> String {
     let html_data_header = if put_html_data_header {
-        println!{"bytedata: {:?}", img[0..10].to_vec()};
-        if img[6..9] == [0x4A, 0x46, 0x49, 0x46] {
+        if img[6..10] == [0x4A, 0x46, 0x49, 0x46] {
             "data:image/jpeg;base64,"
         }
         else if img[0..8] == [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A] {

--- a/hot-finder/src/img_util.rs
+++ b/hot-finder/src/img_util.rs
@@ -2,8 +2,25 @@ use wasm_bindgen::prelude::*;
 
 use base64::{Engine as _, alphabet, engine::{self, general_purpose}};
 
-fn img_to_base64(img: Vec<u8>) -> String {
-    todo!{}
+#[wasm_bindgen]
+pub fn img_to_base64(img: Vec<u8>, put_html_data_header: bool) -> String {
+    let html_data_header = if put_html_data_header {
+        println!{"bytedata: {:?}", img[0..10].to_vec()};
+        if img[6..9] == [0x4A, 0x46, 0x49, 0x46] {
+            "data:image/jpeg;base64,"
+        }
+        else if img[0..8] == [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A] {
+            "data:image/png;base64,"
+        }
+        else {
+            ""
+        }
+    }
+    else {
+        ""
+    };
+
+    (html_data_header.to_owned() + &general_purpose::STANDARD.encode(img)).to_string()
 }
 
 #[wasm_bindgen]

--- a/hot-finder/src/img_util.rs
+++ b/hot-finder/src/img_util.rs
@@ -1,6 +1,6 @@
 use wasm_bindgen::prelude::*;
 
-use base64::{Engine as _, alphabet, engine::{self, general_purpose}};
+use base64::{Engine as _, engine::general_purpose};
 
 #[wasm_bindgen]
 pub fn img_to_base64(img: Vec<u8>, put_html_data_header: bool) -> String {

--- a/hot-finder/tests/base64.rs
+++ b/hot-finder/tests/base64.rs
@@ -34,3 +34,14 @@ fn base64_to_img_byte_with_htmlheader() {
     let res = CORRECT_BYTE_DATA.to_vec();
     assert_eq!(base64_to_img(original), res);
 }
+
+#[wasm_bindgen_test]
+fn img_to_base64_without_htmlheader() {
+    assert_eq!(img_to_base64(CORRECT_BYTE_DATA.to_vec(), false), DATA.to_string());
+}
+
+#[wasm_bindgen_test]
+fn img_to_base64_with_htmlheader() {
+    let res = format!{"data:image/png;base64,{}", DATA};
+    assert_eq!(img_to_base64(CORRECT_BYTE_DATA.to_vec(), true), res);
+}

--- a/hot-finder/tests/base64.rs
+++ b/hot-finder/tests/base64.rs
@@ -45,3 +45,22 @@ fn img_to_base64_with_htmlheader() {
     let res = format!{"data:image/png;base64,{}", DATA};
     assert_eq!(img_to_base64(CORRECT_BYTE_DATA.to_vec(), true), res);
 }
+
+#[wasm_bindgen_test]
+fn check_img_data_equivalent() {
+    let original: String = format!{"data:image/png;base64,{}", DATA};
+    let mid = base64_to_img(original.clone());
+    assert_eq!(img_to_base64(mid.clone(), false), DATA);
+    assert_eq!(img_to_base64(mid, true), original);
+}
+
+#[wasm_bindgen_test]
+fn img_to_base64_jpeg_mock() {
+    // First 32 bytes of real jpeg img
+    let origin: Vec<u8> = vec![0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01, 0x02, 0x00, 0x1c, 0x00, 0x1c, 0x00, 0x00, 0xff, 0xe1, 0x07, 0xd2, 0x45, 0x78, 0x69, 0x66, 0x00, 0x00, 0x49, 0x49];
+    let res1 = "/9j/4AAQSkZJRgABAQIAHAAcAAD/4QfSRXhpZgAASUk=".to_string();
+    let res2 = format!{"data:image/jpeg;base64,{}", &res1};
+
+    assert_eq!(img_to_base64(origin.clone(), false), res1);
+    assert_eq!(img_to_base64(origin, true), res2);
+}


### PR DESCRIPTION
base64_to_imgを実装したので、その逆関数になるimg_to_base64を実装した。

hot-finder/tests/base64.rsのcheck_img_data_equivalentは一方がもう一方の逆関数であることを保証するテストになっている。