### PR TITLE
EventHandlerの整理 #32

### DIFF
--- a/src/engine/component/button.ts
+++ b/src/engine/component/button.ts
@@ -1,4 +1,5 @@
 import Bound from "../geometry/bound";
+import { TouchEndEvent } from "../model/event";
 import { Component } from "./component";
 
 class Button implements Component {
@@ -13,7 +14,7 @@ class Button implements Component {
     round: number,
     text: string,
     color: string | CanvasGradient | CanvasPattern,
-    onClickCallback?: () => void
+    onClickCallback?: () => void,
   ) {
     this.bound = bound;
     this.round = round;
@@ -33,11 +34,11 @@ class Button implements Component {
       this.round,
       Math.PI * (3 / 2),
       0,
-      false
+      false,
     );
     ctx.lineTo(
       this.bound.x + this.bound.width,
-      this.bound.y + this.bound.height - this.round
+      this.bound.y + this.bound.height - this.round,
     );
     ctx.arc(
       this.bound.x + this.bound.width - this.round,
@@ -45,7 +46,7 @@ class Button implements Component {
       this.round,
       0,
       Math.PI * (1 / 2),
-      false
+      false,
     );
     ctx.lineTo(this.bound.x + this.round, this.bound.y + this.bound.height);
     ctx.arc(
@@ -54,7 +55,7 @@ class Button implements Component {
       this.round,
       Math.PI * (1 / 2),
       Math.PI,
-      false
+      false,
     );
     ctx.lineTo(this.bound.x, this.bound.y + this.round);
     ctx.arc(
@@ -63,7 +64,7 @@ class Button implements Component {
       this.round,
       Math.PI,
       Math.PI * (3 / 2),
-      false
+      false,
     );
     ctx.closePath();
     ctx.fill();
@@ -77,11 +78,11 @@ class Button implements Component {
     ctx.fillText(
       this.text,
       this.bound.x + this.bound.width / 2 - textWidth / 2,
-      this.bound.y + this.bound.height / 2 + textSize / 2 - 7
+      this.bound.y + this.bound.height / 2 + textSize / 2 - 7,
     );
   }
 
-  onClick(_: MouseEvent): void {
+  onTouchEnd(_: TouchEndEvent): void {
     if (this.onClickCallback) {
       this.onClickCallback();
     }

--- a/src/engine/component/component.ts
+++ b/src/engine/component/component.ts
@@ -1,11 +1,14 @@
 import Bound from "../geometry/bound";
 import Point from "../geometry/point";
+import { TouchEndEvent, TouchMoveEvent, TouchStartEvent } from "../model/event";
 
 export interface Component {
   bound: Bound;
   draw(context: CanvasRenderingContext2D): void;
 
-  onClick?(event: MouseEvent): void;
   onScratch?(previousCursor: Point, currentCursor: Point): void;
   onSceneChanged?(): void;
+  onTouchStart?(event: TouchStartEvent): void;
+  onTouchMove?(event: TouchMoveEvent): void;
+  onTouchEnd?(event: TouchEndEvent): void;
 }

--- a/src/engine/component/component.ts
+++ b/src/engine/component/component.ts
@@ -3,12 +3,24 @@ import Point from "../geometry/point";
 import { TouchEndEvent, TouchMoveEvent, TouchStartEvent } from "../model/event";
 
 export interface Component {
+  // コンポーネントの領域
   bound: Bound;
+
+  // 画面が描画される時
   draw(context: CanvasRenderingContext2D): void;
 
+  // 画面が擦られた時
   onScratch?(previousCursor: Point, currentCursor: Point): void;
+
+  // シーンが変化した時 (ただし、コンポーネントが前後両方のシーンで有効である必要がある)
   onSceneChanged?(): void;
+
+  // タッチされた最初のフレームの時
   onTouchStart?(event: TouchStartEvent): void;
+
+  // タッチされている時
   onTouchMove?(event: TouchMoveEvent): void;
+
+  // タッチが離された時、またはタッチがコンポーネントから外れた時
   onTouchEnd?(event: TouchEndEvent): void;
 }

--- a/src/engine/component/shatter.ts
+++ b/src/engine/component/shatter.ts
@@ -1,4 +1,5 @@
 import Bound from "../geometry/bound";
+import { TouchEndEvent } from "../model/event";
 import { Component } from "./component";
 
 class Shatter implements Component {
@@ -32,7 +33,7 @@ class Shatter implements Component {
     context.fill();
   }
 
-  onClick(_: MouseEvent) {
+  onTouchEnd(_: TouchEndEvent): void {
     this.shotCallback(this.videoElement);
   }
 }

--- a/src/engine/executor.ts
+++ b/src/engine/executor.ts
@@ -96,23 +96,20 @@ class GameExecutor {
       case "touchmove": {
         const touchMoveEvent = new TouchMoveEvent(event as TouchEvent);
         this.invokeOnScratchEvent(
-          new Point(touchMoveEvent.pageX, touchMoveEvent.pageY),
+          new Point(touchMoveEvent.x, touchMoveEvent.y),
           components,
         );
         components.forEach((component, index) => {
           if (
             component.onTouchMove &&
-            component.bound.includes(touchMoveEvent.pageX, touchMoveEvent.pageY)
+            component.bound.includes(touchMoveEvent.x, touchMoveEvent.y)
           ) {
             component.onTouchMove(touchMoveEvent);
           }
           if (
             index == this.touchingComponentIndex &&
             component.onTouchEnd &&
-            !component.bound.includes(
-              touchMoveEvent.pageX,
-              touchMoveEvent.pageY,
-            )
+            !component.bound.includes(touchMoveEvent.x, touchMoveEvent.y)
           ) {
             component.onTouchEnd(touchMoveEvent);
             this.touchingComponentIndex = null;
@@ -125,10 +122,7 @@ class GameExecutor {
         components.forEach((component, index) => {
           if (
             component.onTouchStart &&
-            component.bound.includes(
-              touchStartEvent.pageX,
-              touchStartEvent.pageY,
-            )
+            component.bound.includes(touchStartEvent.x, touchStartEvent.y)
           ) {
             component.onTouchStart(touchStartEvent);
             this.touchingComponentIndex = index;
@@ -141,7 +135,7 @@ class GameExecutor {
         components.forEach((component) => {
           if (
             component.onTouchEnd &&
-            component.bound.includes(touchEndEvent.pageX, touchEndEvent.pageY)
+            component.bound.includes(touchEndEvent.x, touchEndEvent.y)
           ) {
             component.onTouchEnd(touchEndEvent);
           }

--- a/src/engine/executor.ts
+++ b/src/engine/executor.ts
@@ -4,6 +4,8 @@ import { InitializeComponents, Scene } from "./componentTimeline";
 import Point from "./geometry/point";
 import { TouchEndEvent, TouchMoveEvent } from "./model/event";
 
+// HTML/Canvas/Videoの機能を抽象化し、ゲームとしてプロセスを実行するクラス
+// 主な役割は、フレーム管理、コンポーネント管理、入力イベントの分配
 class GameExecutor {
   private scene: Scene;
   private canvas: HTMLCanvasElement;
@@ -23,12 +25,15 @@ class GameExecutor {
     this.touchingComponentIndex = null;
   }
 
+  // 処理を開始する
+  // 一度呼ばれると、this.processFrameを経由して再帰的に呼ばれ続ける
   invokeProcess() {
     window.requestAnimationFrame(() => {
       this.processFrame();
     });
   }
 
+  // シーンを変更する
   stageScene(scene: Scene) {
     const components = this.componentContainer.queryEnabledComponents([
       this.scene,
@@ -49,6 +54,7 @@ class GameExecutor {
     }
   }
 
+  // 画面が擦られたかどうかを判定し、そうである場合は各コンポーネントのonScratchを呼び出す
   private invokeOnScratchEvent(currentCursor: Point, components: Component[]) {
     this.scratchCursorQueue.push(currentCursor);
 
@@ -76,6 +82,7 @@ class GameExecutor {
     }
   }
 
+  // イベントを受け取る
   listen(eventType: string, event: Event) {
     event.stopPropagation();
 
@@ -83,6 +90,8 @@ class GameExecutor {
       this.scene,
     ]);
 
+    // 各イベントに対してパターンマッチング
+    // 有効なイベントの種類は、main.tsにてstartGameの引数として渡される
     switch (eventType) {
       case "touchmove": {
         const touchMoveEvent = new TouchMoveEvent(event as TouchEvent);
@@ -143,6 +152,7 @@ class GameExecutor {
     }
   }
 
+  // フレームが更新されたときの処理。主に描画を行う
   processFrame() {
     const context = this.canvas.getContext("2d") as CanvasRenderingContext2D;
     context.clearRect(0, 0, this.canvas.width, this.canvas.height);

--- a/src/engine/model/event.ts
+++ b/src/engine/model/event.ts
@@ -1,26 +1,32 @@
 export class TouchStartEvent {
-  pageX: number;
-  pageY: number;
+  // X (pageX) 座標
+  x: number;
+  // Y (pageY) 座標
+  y: number;
   constructor(event: TouchEvent) {
-    this.pageX = event.changedTouches[0].pageX;
-    this.pageY = event.changedTouches[0].pageY;
+    this.x = event.changedTouches[0].pageX;
+    this.y = event.changedTouches[0].pageY;
   }
 }
 
 export class TouchMoveEvent {
-  pageX: number;
-  pageY: number;
+  // X (pageX) 座標
+  x: number;
+  // Y (pageY) 座標
+  y: number;
   constructor(event: TouchEvent) {
-    this.pageX = event.changedTouches[0].pageX;
-    this.pageY = event.changedTouches[0].pageY;
+    this.x = event.changedTouches[0].pageX;
+    this.y = event.changedTouches[0].pageY;
   }
 }
 
 export class TouchEndEvent {
-  pageX: number;
-  pageY: number;
+  // X (pageX) 座標
+  x: number;
+  // Y (pageY) 座標
+  y: number;
   constructor(event: TouchEvent) {
-    this.pageX = event.changedTouches[0].pageX;
-    this.pageY = event.changedTouches[0].pageY;
+    this.x = event.changedTouches[0].pageX;
+    this.y = event.changedTouches[0].pageY;
   }
 }

--- a/src/engine/model/event.ts
+++ b/src/engine/model/event.ts
@@ -1,0 +1,26 @@
+export class TouchStartEvent {
+  pageX: number;
+  pageY: number;
+  constructor(event: TouchEvent) {
+    this.pageX = event.changedTouches[0].pageX;
+    this.pageY = event.changedTouches[0].pageY;
+  }
+}
+
+export class TouchMoveEvent {
+  pageX: number;
+  pageY: number;
+  constructor(event: TouchEvent) {
+    this.pageX = event.changedTouches[0].pageX;
+    this.pageY = event.changedTouches[0].pageY;
+  }
+}
+
+export class TouchEndEvent {
+  pageX: number;
+  pageY: number;
+  constructor(event: TouchEvent) {
+    this.pageX = event.changedTouches[0].pageX;
+    this.pageY = event.changedTouches[0].pageY;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,8 @@ import GameExecutor from "./engine/executor";
 import ExecuteVideoElement from "./engine/video/exec";
 import "./style.css";
 
+// ゲームを開始する
+// 有効なイベントを引数として指定することで、そのイベントをゲームに反映させる
 function startGame(availableEvents: string[] = []) {
   const videoElement = document.createElement("video");
   ExecuteVideoElement(
@@ -17,8 +19,9 @@ function startGame(availableEvents: string[] = []) {
           gameExecutor.listen(eventType, event);
         });
       });
-      // initial scene
+      // 最初のシーンを設定
       gameExecutor.stageScene("take!");
+      // 処理を開始
       gameExecutor.invokeProcess();
     },
     (err) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,5 +28,5 @@ function startGame(availableEvents: string[] = []) {
 }
 
 window.onload = () => {
-  startGame(["click", "touchmove", "mousemove"]);
+  startGame(["touchmove", "touchstart", "touchend"]);
 };

--- a/src/style.css
+++ b/src/style.css
@@ -1,3 +1,4 @@
 body {
   margin: 0;
+  overflow: hidden; /* 画面をスクロールさせないため */
 }


### PR DESCRIPTION
具体的な実装内容は #32 にて

各イベントの発火条件もinterface:Component中のコメントに追加している (どさくさにまぎれて他の部分もコメントを増強している)

その際、画面のスクロールをpreventDefaultで止める処理にて、コンソールにwarningが表示される上、有効ではない環境も存在した。
そのため、イベント関連の実装の変更に伴い、cssでのoverflow属性の追加による制限に変更した。