### PR TITLE
ゲーム全体のシーン遷移の最低限実装

### DIFF
--- a/src/engine/component/component.ts
+++ b/src/engine/component/component.ts
@@ -1,6 +1,7 @@
 import Bound from "../geometry/bound";
 import Point from "../geometry/point";
 import { TouchEndEvent, TouchMoveEvent, TouchStartEvent } from "../model/event";
+import { Scene } from "../model/scene";
 
 export interface Component {
   // コンポーネントの領域
@@ -13,7 +14,7 @@ export interface Component {
   onScratch?(previousCursor: Point, currentCursor: Point): void;
 
   // シーンが変化した時 (ただし、コンポーネントが前後両方のシーンで有効である必要がある)
-  onSceneChanged?(): void;
+  onSceneChanged?(previousScene: Scene, currentScene: Scene): void;
 
   // タッチされた最初のフレームの時
   onTouchStart?(event: TouchStartEvent): void;

--- a/src/engine/component/icecup.ts
+++ b/src/engine/component/icecup.ts
@@ -1,13 +1,65 @@
 import Bound from "../geometry/bound";
+import { Scene } from "../model/scene";
 import { Component } from "./component";
+
+const SYRUP_VISIBLE_DURATION = 100;
+
+async function createSyrupImage(
+  baseImage: HTMLImageElement,
+  color: [number, number, number],
+) {
+  const canvas = document.createElement("canvas");
+  canvas.width = baseImage.width;
+  canvas.height = baseImage.height;
+  const context = canvas.getContext("2d")!;
+  context.drawImage(baseImage, 0, 0, baseImage.width, baseImage.height);
+  const baseImageData = context.getImageData(
+    0,
+    0,
+    baseImage.width,
+    baseImage.height,
+  );
+
+  const width = baseImageData.width;
+  const height = baseImageData.height;
+  let syrupImageData = new ImageData(width, height);
+  // ピクセルが透明でなく、かつ白でない場合、色を塗る
+  for (let i = 0; i < baseImage.width * baseImage.height; i++) {
+    const r = baseImageData.data[i * 4 + 0];
+    const g = baseImageData.data[i * 4 + 1];
+    const b = baseImageData.data[i * 4 + 2];
+    const a = baseImageData.data[i * 4 + 3];
+    if (a == 255 && !(r == 255 && g == 255 && b == 255)) {
+      syrupImageData.data[i * 4 + 0] = color[0] * 255;
+      syrupImageData.data[i * 4 + 1] = color[1] * 255;
+      syrupImageData.data[i * 4 + 2] = color[2] * 255;
+      syrupImageData.data[i * 4 + 3] = 255;
+    }
+  }
+
+  return createImageBitmap(syrupImageData);
+}
 
 class Icecup implements Component {
   bound: Bound;
   private goalBound: Bound;
-  private image: HTMLImageElement | null;
-  private clock;
+  private icecupImage: HTMLImageElement | null;
+  private syrupImage: ImageBitmap | null;
+  private baseSyrupImage: HTMLImageElement | null;
+  private syrupColor: [number, number, number] | null;
+  private finishClock: number;
+  private syrupClock: number;
+  private syrupOpacity: number;
+  private moveFinishedCallback: () => void;
+  private syrupFinishedCallback: () => void;
 
-  constructor(bound: Bound, canvasWidth: number, canvasHeight: number) {
+  constructor(
+    bound: Bound,
+    canvasWidth: number,
+    canvasHeight: number,
+    moveFinishedCallback: () => void,
+    syrupFinishedCallback: () => void,
+  ) {
     this.bound = bound;
     const goalWidth = Math.min(canvasWidth, canvasHeight) * 0.75;
     this.goalBound = new Bound(
@@ -16,32 +68,103 @@ class Icecup implements Component {
       goalWidth,
       goalWidth,
     );
-    this.image = null;
-    this.clock = -1;
-    const image = new Image();
-    image.src = "images/icecup.webp";
-    image.onload = () => {
-      this.image = image;
+
+    this.finishClock = -1;
+    this.syrupClock = -1;
+    this.syrupOpacity = 0;
+
+    this.icecupImage = null;
+    const icecupImage = new Image();
+    icecupImage.src = "images/icecup.webp";
+    icecupImage.onload = () => {
+      this.icecupImage = icecupImage;
     };
+    this.baseSyrupImage = null;
+    const baseSyrupImage = new Image();
+    baseSyrupImage.src = "images/syrup.webp";
+    baseSyrupImage.onload = () => {
+      this.baseSyrupImage = baseSyrupImage;
+    };
+    this.syrupImage = null;
+    this.syrupColor = null;
+
+    this.moveFinishedCallback = moveFinishedCallback;
+    this.syrupFinishedCallback = syrupFinishedCallback;
   }
 
-  onSceneChanged() {
-    this.clock = 0;
+  onSceneChanged(_: Scene, scene: Scene) {
+    this.finishClock = -1;
+    this.syrupClock = -1;
+    if (scene == "finish") {
+      this.finishClock = 0;
+    }
+    if (scene == "syruptime") {
+      this.syrupColor = [0.5, 0.7, 1.0];
+      createSyrupImage(this.baseSyrupImage!, this.syrupColor).then(
+        (syrupImage) => {
+          this.syrupImage = syrupImage;
+        },
+      );
+      this.syrupClock = 0;
+    }
   }
 
   draw(context: CanvasRenderingContext2D) {
-    if (this.clock >= 0) {
-      this.clock += 1;
+    if (this.finishClock >= 0) {
+      this.finishClock += 1;
       this.bound.animateTo(this.goalBound, 0.05);
+      if (Math.abs(this.bound.y - this.goalBound.y) < 1) {
+        this.moveFinishedCallback();
+      }
     }
-    if (this.image) {
+    if (this.syrupClock >= 0) {
+      this.syrupClock += 1;
+      const syrupWidth = this.bound.width * 0.02;
+      const syrupMoveRange = this.bound.width * 0.3;
+      const syrupX =
+        this.bound.x +
+        syrupMoveRange * Math.cos(this.syrupClock / 7) +
+        this.bound.width * 0.5;
+      const syrupOpacity = Math.min(
+        Math.sin((this.syrupClock / SYRUP_VISIBLE_DURATION) * Math.PI) * 2,
+        1,
+      );
+      const syrupColor = this.syrupColor || [0.5, 0.5, 0.5];
+      context.fillStyle = `rgba(${syrupColor[0] * 255}, ${
+        syrupColor[1] * 255
+      }, ${syrupColor[2] * 255}, ${syrupOpacity})`;
+      context.fillRect(
+        syrupX,
+        0,
+        syrupWidth,
+        this.bound.y + this.bound.height / 2,
+      );
+
+      this.syrupOpacity = Math.min(this.syrupClock / SYRUP_VISIBLE_DURATION, 1);
+      if (this.syrupClock >= SYRUP_VISIBLE_DURATION) {
+        this.syrupFinishedCallback();
+        this.syrupClock = -1;
+      }
+    }
+    if (this.icecupImage) {
       context.drawImage(
-        this.image,
+        this.icecupImage,
         this.bound.x,
         this.bound.y,
         this.bound.width,
         this.bound.height,
       );
+    }
+    if (this.syrupImage) {
+      context.globalAlpha = this.syrupOpacity;
+      context.drawImage(
+        this.syrupImage,
+        this.bound.x,
+        this.bound.y,
+        this.bound.width,
+        this.bound.height,
+      );
+      context.globalAlpha = 1;
     }
   }
 }

--- a/src/engine/componentContainer.ts
+++ b/src/engine/componentContainer.ts
@@ -1,5 +1,5 @@
 import { Component } from "./component/component";
-import { Scene } from "./componentTimeline";
+import { Scene } from "./model/scene";
 
 class ComponentContainer {
   private components: Component[];

--- a/src/engine/componentTimeline.ts
+++ b/src/engine/componentTimeline.ts
@@ -6,8 +6,7 @@ import VideoPreview from "./component/videoPreview";
 import Bound from "./geometry/bound";
 import GameRouter from "./executor";
 import { CropImageFromVideo } from "./video/crop";
-
-export type Scene = "none" | "take!" | "scratch!" | "satisfied";
+import Button from "./component/button";
 
 // scratch!シーンを終える条件となる、残りアツピクセル比率のしきい値
 const SCRATCH_FINISH_HOTPROP_THRESHOLD = 0.15;
@@ -21,17 +20,24 @@ export function InitializeComponents(
 ) {
   let componentContainer: ComponentContainer = new ComponentContainer();
 
-  let hotPropChanged: (hotProp: number) => void;
+  let scratchableImageHotPropChanged: (hotProp: number) => void;
   const scratchableImage = new ScratchableImage(
     new Bound(0, 0, canvas.width, canvas.height),
+    () => {
+      router.stageScene("scratch!");
+    },
     (hotProp) => {
       if (hotProp < SCRATCH_FINISH_HOTPROP_THRESHOLD) {
-        router.stageScene("satisfied");
+        router.stageScene("finish");
       }
-      hotPropChanged(hotProp);
+      scratchableImageHotPropChanged(hotProp);
     },
   );
-  componentContainer.addComponent(scratchableImage, ["scratch!", "satisfied"]);
+  componentContainer.addComponent(scratchableImage, [
+    "flush",
+    "scratch!",
+    "finish",
+  ]);
 
   componentContainer.addComponent(
     new VideoPreview(
@@ -55,7 +61,7 @@ export function InitializeComponents(
         scratchableImage.setImageData(
           CropImageFromVideo(videoElement, canvas.width, canvas.height),
         );
-        router.stageScene("scratch!");
+        router.stageScene("flush");
       },
     ),
     ["take!"],
@@ -71,13 +77,59 @@ export function InitializeComponents(
     ),
     canvas.width,
     canvas.height,
+    () => {
+      router.stageScene("satisfied");
+    },
+    () => {
+      router.stageScene("result");
+    },
   );
-  componentContainer.addComponent(icecup, ["scratch!", "satisfied"]);
+  componentContainer.addComponent(icecup, [
+    "scratch!",
+    "finish",
+    "satisfied",
+    "syruptime",
+    "result",
+  ]);
 
-  hotPropChanged = (hotProp) => {
+  scratchableImageHotPropChanged = (hotProp) => {
     icecup.bound.y =
       canvas.height - icecupWidth * (1.0 - hotProp) * ICECUP_RAISING_RATIO;
   };
+
+  const satisfiedButtonWidth = Math.min(canvas.width, canvas.height) * 0.4;
+  const satisfiedButton = new Button(
+    new Bound(
+      canvas.width / 2 - satisfiedButtonWidth / 2,
+      canvas.height - satisfiedButtonWidth,
+      satisfiedButtonWidth,
+      satisfiedButtonWidth * 0.4,
+    ),
+    20,
+    "result",
+    "rgb(100, 100, 100)",
+    () => {
+      router.stageScene("syruptime");
+    },
+  );
+  componentContainer.addComponent(satisfiedButton, ["satisfied"]);
+
+  const resultButtonWidth = Math.min(canvas.width, canvas.height) * 0.4;
+  const resultButton = new Button(
+    new Bound(
+      canvas.width / 2 - satisfiedButtonWidth / 2,
+      canvas.height - satisfiedButtonWidth,
+      satisfiedButtonWidth,
+      satisfiedButtonWidth * 0.4,
+    ),
+    20,
+    "again",
+    "rgb(100, 100, 100)",
+    () => {
+      router.stageScene("take!");
+    },
+  );
+  componentContainer.addComponent(resultButton, ["result"]);
 
   return componentContainer;
 }

--- a/src/engine/componentTimeline.ts
+++ b/src/engine/componentTimeline.ts
@@ -117,10 +117,10 @@ export function InitializeComponents(
   const resultButtonWidth = Math.min(canvas.width, canvas.height) * 0.4;
   const resultButton = new Button(
     new Bound(
-      canvas.width / 2 - satisfiedButtonWidth / 2,
-      canvas.height - satisfiedButtonWidth,
-      satisfiedButtonWidth,
-      satisfiedButtonWidth * 0.4,
+      canvas.width / 2 - resultButtonWidth / 2,
+      canvas.height - resultButtonWidth,
+      resultButtonWidth,
+      resultButtonWidth * 0.4,
     ),
     20,
     "again",

--- a/src/engine/executor.ts
+++ b/src/engine/executor.ts
@@ -1,8 +1,9 @@
 import { Component } from "./component/component";
 import ComponentContainer from "./componentContainer";
-import { InitializeComponents, Scene } from "./componentTimeline";
+import { InitializeComponents } from "./componentTimeline";
 import Point from "./geometry/point";
 import { TouchEndEvent, TouchMoveEvent } from "./model/event";
+import { Scene } from "./model/scene";
 
 // HTML/Canvas/Videoの機能を抽象化し、ゲームとしてプロセスを実行するクラス
 // 主な役割は、フレーム管理、コンポーネント管理、入力イベントの分配
@@ -19,7 +20,7 @@ class GameExecutor {
     this.scene = "none";
     this.canvas = canvas;
     this.videoElement = videoElement;
-    this.componentContainer = InitializeComponents(this, canvas, videoElement);
+    this.componentContainer = new ComponentContainer();
     this.scratchCursorQueue = [];
     this.previousCursorDiff = new Point(-1, -1);
     this.touchingComponentIndex = null;
@@ -41,13 +42,18 @@ class GameExecutor {
     ]);
     components.forEach((component) => {
       if (component.onSceneChanged) {
-        component.onSceneChanged();
+        component.onSceneChanged(this.scene, scene);
       }
     });
 
     this.scene = scene;
 
     if (scene == "take!") {
+      this.componentContainer = InitializeComponents(
+        this,
+        this.canvas,
+        this.videoElement,
+      );
       this.videoElement.play();
     } else {
       this.videoElement.pause();

--- a/src/engine/model/scene.ts
+++ b/src/engine/model/scene.ts
@@ -1,0 +1,9 @@
+export type Scene =
+  | "none"
+  | "take!"
+  | "flush"
+  | "scratch!"
+  | "finish"
+  | "satisfied"
+  | "syruptime"
+  | "result";


### PR DESCRIPTION
```typescript
export type Scene =
  | "none"
  | "take!"
  | "flush"
  | "scratch!"
  | "finish"
  | "satisfied"
  | "syruptime"
  | "result";
```

以下のシーンを追加し、ゲームの全体の流れを簡単に実装
 - "flush": カメラのフラッシュを切る演出時
 - "finish": 写真を削り切り、かき氷が現れる演出時
 - "syruptime": シロップをかける演出時
 - "result" 結果の表示時