### PR TITLE
game.htmlにアクセス可能に

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite'
+import { resolve } from 'path'
+
+export default defineConfig({
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        game: resolve(__dirname, 'game.html')
+      }
+    }
+  }
+});


### PR DESCRIPTION
デプロイ結果を見たところ、game.htmlにアクセスできなかった
調査したところ、distディレクトリ内にindex.htmlしかビルドされていなかった

`vite.config.js`を追加し、game.htmlもルートするようにした