### PR TITLE
WASM: 熱い部分を切り抜く機能を実装

### DIFF
--- a/hot-finder/Cargo.toml
+++ b/hot-finder/Cargo.toml
@@ -12,7 +12,6 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 wasm-bindgen = "0.2.84"
-rand = "0.8.4"
 base64 = "0.21.5"
 image = "0.24.7"
 getrandom = {version = "0.2", features = ["js"]}
@@ -25,7 +24,6 @@ console_error_panic_hook = { version = "0.1.7", optional = true }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.34"
-rand = "0.8.4"
 base64 = "0.21.5"
 image = "0.24.7"
 getrandom = {version = "0.2", features = ["js"]}

--- a/hot-finder/src/img_util.rs
+++ b/hot-finder/src/img_util.rs
@@ -1,6 +1,7 @@
 use wasm_bindgen::prelude::*;
 
 use base64::{Engine as _, engine::general_purpose};
+use image::Rgba;
 use crate::hsv::Hsv;
 
 /// Classify a pixel is hot or not.
@@ -11,6 +12,10 @@ pub(crate) fn is_pixel_hot(pixel: &Hsv) -> bool {
     let is_in_value_range = 10.0 <= pixel.get_value();
 
     is_in_hue_range && is_in_satu_range && is_in_value_range
+}
+
+pub(crate) fn to_transparent(pixel: &Rgba<u8>) -> Rgba<u8> {
+    Rgba::<u8>([pixel[0], pixel[1], pixel[2], 0u8])
 }
 
 /// Convert an image binary (Vec<u8>) to a base64 (String).

--- a/hot-finder/src/lib.rs
+++ b/hot-finder/src/lib.rs
@@ -7,10 +7,9 @@ use wasm_bindgen::prelude::*;
 use std::io::Cursor;
 use std::error::Error;
 use hsv::to_hsv;
-use image::DynamicImage;
 use image::io::Reader as ImageReader;
-use image::GenericImageView;
-use img_util::{base64_to_img, is_pixel_hot};
+use image::{GenericImageView, DynamicImage, RgbaImage, ImageOutputFormat};
+use img_util::{base64_to_img, img_to_base64, is_pixel_hot, to_transparent};
 
 fn byte_to_image(bytes: Vec<u8>) -> Result<DynamicImage, Box<dyn Error + Send + Sync + 'static>> {
     Ok(ImageReader::new(Cursor::new(bytes)).with_guessed_format()?.decode()?)
@@ -41,7 +40,24 @@ pub fn evaluate_hotness(img: String) -> f64 {
 /// The output of this function is base64 encoded PNG image.
 #[wasm_bindgen]
 pub fn extract_hot_buffer(img: String) -> String {
-    img
+    let res = match byte_to_image(base64_to_img(img.clone())) {
+        Ok(image) => {
+            let mut imgbuf = RgbaImage::new(image.width(), image.height());
+            for (x, y, px) in image.pixels() {
+                let hsvpx = to_hsv(&px);
+                imgbuf.put_pixel(x, y, if is_pixel_hot(&hsvpx) { px } else { to_transparent(&px) });
+            }
+
+            let mut bytes: Vec<u8> = Vec::new();
+            imgbuf.write_to(&mut Cursor::new(&mut bytes), ImageOutputFormat::Png).unwrap();
+            img_to_base64(bytes, true)
+        },
+        Err(_) => {
+            img
+        }
+    };
+
+    res
 }
 
 #[cfg(test)]
@@ -72,6 +88,23 @@ mod tests {
 
         let b64_img = img_util::img_to_base64(buf, true);
         println!{"{}", evaluate_hotness(b64_img)};
+        assert_eq!(1+1, 2);
+    }
+
+    // Tests hot_extract_* always pass.
+    // These tests can be used to check and debug.
+    // You have to use redirect(>) and vim to edit it because output (b64String) is extremely long.
+
+    #[test]
+    fn hot_extract_yamaokaya() {
+        let mut file = File::open("./test_assets/IMG_4244_resized.png").unwrap();
+        let mut buf: Vec<u8> = Vec::new();
+        file.read_to_end(&mut buf).unwrap();
+
+        let b64_img = img_util::img_to_base64(buf, true);
+        let res = extract_hot_buffer(b64_img);
+        println!{"{}", res};
+
         assert_eq!(1+1, 2);
     }
 }


### PR DESCRIPTION
まだ熱い部分を切り抜くために使っている条件が雑なので、調整の余地がある。
調整すればそこそこいい感じの評価関数になりそうという気持ちがある。